### PR TITLE
99.46% Coverage

### DIFF
--- a/lib/Instance_spec.lua
+++ b/lib/Instance_spec.lua
@@ -91,6 +91,16 @@ describe("Instance", function()
 			assert.equal(child.Parent, parent2)
 			assert.equal(parent2:FindFirstChild("foo"), child)
 		end)
+
+		-- This may seem like a weird test, but it's for 100% coverage
+		it("shouldn't react differently when setting the parent to the existing parent", function()
+			local parent = Instance.new("Folder")
+			local object = Instance.new("Folder", parent)
+
+			assert.has_no_errors(function()
+				object.Parent = parent
+			end)
+		end)
 	end)
 
 	describe("FindFirstChild", function()

--- a/lib/fs_spec.lua
+++ b/lib/fs_spec.lua
@@ -1,0 +1,18 @@
+describe("fs", function()
+	local fs = import("./fs")
+
+	it("should return errors when failing to open a file", function()
+		local contents, err = fs.read("nuclear launch codes.txt")
+
+		assert.is_nil(contents)
+		assert.is_not_nil(err)
+	end)
+
+	it("should return contents of files read", function()
+		local contents, err = fs.read("init.lua")
+
+		assert.is_not_nil(contents)
+		assert.is_nil(err)
+		assert.is_true(#contents > 0)
+	end)
+end)

--- a/lib/functions/warn_spec.lua
+++ b/lib/functions/warn_spec.lua
@@ -3,7 +3,7 @@ local warn = import("./warn")
 local function setupWarnDetour()
 	local oldErr = io.stderr
 
-	local writeSpy = spy.new(function(_, msg) end)
+	local writeSpy = spy.new(function() end)
 
 	io.stderr = { -- luacheck: ignore
 		write = writeSpy

--- a/lib/functions/warn_spec.lua
+++ b/lib/functions/warn_spec.lua
@@ -1,23 +1,33 @@
 local warn = import("./warn")
 
+local function setupWarnDetour()
+	local oldErr = io.stderr
+
+	local writeSpy = spy.new(function(_, msg) end)
+
+	io.stderr = { -- luacheck: ignore
+		write = writeSpy
+	}
+
+	return oldErr, writeSpy
+end
+
 describe("functions.warn", function()
 	it("should be a function", function()
 		assert.is_function(warn)
 	end)
 
 	it("should warn", function()
-		local oldErr = io.stderr
-
-		local writeSpy = spy.new(function(_, msg) end)
-
-		io.stderr = { -- luacheck: ignore
-			write = writeSpy
-		}
-
+		local oldErr, writeSpy = setupWarnDetour()
 		warn("Doge has taken over the world!")
-
 		assert.spy(writeSpy).was_called_with(io.stderr, "Doge has taken over the world!")
+		io.stderr = oldErr -- luacheck: ignore
+	end)
 
+	it("should warn with multiple arguments", function()
+		local oldErr, writeSpy = setupWarnDetour()
+		warn("IT'S DOGE!", "AAH!")
+		assert.spy(writeSpy).was.called(3) -- IT'S DOGE, \t, AAH!
 		io.stderr = oldErr -- luacheck: ignore
 	end)
 end)


### PR DESCRIPTION
There are two files left that don't have full coverage and they're bothering me a lot.

- fs.lua - No coverage for testing if it errors when lfs isn't installed. No matter what trick I try (overriding require, overriding pcall, getfenv() wizardry), I cannot get it to think lfs isn't installed.
- Enum/init.lua - We have no Enums, so the block of code for including one isn't covered.