### PR TITLE
Expand Destroy()

### DIFF
--- a/lib/Instance.lua
+++ b/lib/Instance.lua
@@ -36,6 +36,11 @@ Instance.properties.Parent = {
 	end,
 	set = function(self, key, value)
 		local internal = self._internal
+
+		if internal.destroyed then
+			error("Attempt to set parent after being destroyed!")
+		end
+
 		if internal.parent == value then
 			return
 		end
@@ -176,10 +181,11 @@ function Instance:Destroy()
 		child:Destroy()
 	end
 
-	self._internal.parent = nil --Sometimes Destroy() is called on already destroyed children
-	self.properties.Parent.set = function()
-		error("Attempt to set parent after being destroyed!") --This isn't the exact error, does it matter?
+	if self.Parent then
+		self.Parent = nil
 	end
+
+	self._internal.destroyed = true
 end
 
 --[[

--- a/lib/Instance.lua
+++ b/lib/Instance.lua
@@ -172,10 +172,14 @@ function Instance:IsA(className)
 end
 
 function Instance:Destroy()
-	self.Parent = nil
+	for child in pairs(self._internal.children) do
+		child:Destroy()
+	end
 
-	-- TODO: Destruct all children first
-	-- TODO: Lock the parent!
+	self._internal.parent = nil --Sometimes Destroy() is called on already destroyed children
+	self.properties.Parent.set = function()
+		error("Attempt to set parent after being destroyed!") --This isn't the exact error, does it matter?
+	end
 end
 
 --[[

--- a/lib/Instance_spec.lua
+++ b/lib/Instance_spec.lua
@@ -143,6 +143,24 @@ describe("Instance", function()
 
 			assert.equal(child.Parent, nil)
 		end)
+
+		it("should set the children's parents to nil", function()
+			local parent = Instance.new("Folder")
+			local child = Instance.new("Folder", parent)
+			parent:Destroy()
+			assert.equal(child.Parent, nil)
+		end)
+
+		it("should lock the parent property", function()
+			local instance = Instance.new("Folder")
+			local badParent = Instance.new("Folder")
+
+			instance:Destroy()
+
+			assert.has.errors(function()
+				instance.Parent = badParent
+			end)
+		end)
 	end)
 
 	describe("IsA", function()

--- a/lib/Instance_spec.lua
+++ b/lib/Instance_spec.lua
@@ -161,6 +161,19 @@ describe("Instance", function()
 				instance.Parent = badParent
 			end)
 		end)
+
+		it("should only lock its own instance, and not all of the same type", function()
+			local destroyFolder = Instance.new("Folder")
+			destroyFolder:Destroy()
+			assert.equal(destroyFolder.Parent, nil)
+
+			local goodParent = Instance.new("Folder")
+			local goodFolder = Instance.new("Folder")
+
+			assert.has_no.errors(function()
+				goodFolder.Parent = goodParent
+			end)
+		end)
 	end)
 
 	describe("IsA", function()


### PR DESCRIPTION
I went TODO hunting.

- Destroy() now calls Destroy() on all of its children
- Destroy() now locks the parent property of the instance being destroyed