### PR TITLE
Add GetFullName

### DIFF
--- a/lib/Instance_spec.lua
+++ b/lib/Instance_spec.lua
@@ -222,6 +222,18 @@ describe("Instance", function()
 			local fullName = instance:GetFullName()
 			assert.equal("Parent.Test", fullName)
 		end)
+
+		it("should exclude game", function()
+			local instance = Instance.new("Folder")
+			instance.Name = "Test"
+			local other = Instance.new("Game")
+			other.Name = "Parent"
+
+			instance.Parent = other
+
+			local fullName = instance:GetFullName()
+			assert.equal("Test", fullName)
+		end)
 	end)
 
 	describe("tostring", function()

--- a/lib/Instance_spec.lua
+++ b/lib/Instance_spec.lua
@@ -234,6 +234,14 @@ describe("Instance", function()
 			local fullName = instance:GetFullName()
 			assert.equal("Test", fullName)
 		end)
+
+		it("should return the instance name if there is no parent", function()
+			local instance = Instance.new("Folder")
+			instance.Name = "Test"
+
+			local fullName = instance:GetFullName()
+			assert.equal("Test", fullName)
+		end)
 	end)
 
 	describe("tostring", function()

--- a/lib/Instance_spec.lua
+++ b/lib/Instance_spec.lua
@@ -210,6 +210,20 @@ describe("Instance", function()
 		end)
 	end)
 
+	describe("GetFullName", function()
+		it("should get the full name", function()
+			local instance = Instance.new("Folder")
+			instance.Name = "Test"
+			local other = Instance.new("Folder")
+			other.Name = "Parent"
+
+			instance.Parent = other
+
+			local fullName = instance:GetFullName()
+			assert.equal("Parent.Test", fullName)
+		end)
+	end)
+
 	describe("tostring", function()
 		it("should match the name of the instance", function()
 			local instance = Instance.new("Folder")

--- a/lib/instances/BaseInstance.lua
+++ b/lib/instances/BaseInstance.lua
@@ -132,6 +132,18 @@ function BaseInstance.prototype:GetPropertyChangedSignal(key)
 	return listener
 end
 
+function BaseInstance.prototype:GetFullName()
+	local name = self.Name
+	local level = self.Parent
+
+	while level do
+		name = level.Name .. "." .. name
+		level = level.Parent
+	end
+
+	return name
+end
+
 BaseInstance.metatable = {}
 BaseInstance.metatable.type = "Instance"
 

--- a/lib/instances/BaseInstance.lua
+++ b/lib/instances/BaseInstance.lua
@@ -136,7 +136,7 @@ function BaseInstance.prototype:GetFullName()
 	local name = self.Name
 	local level = self.Parent
 
-	while level do
+	while level and getmetatable(level).class.name ~= "DataModel" do
 		name = level.Name .. "." .. name
 		level = level.Parent
 	end


### PR DESCRIPTION
Fixes #22. Not a lot else to say. This should be an exact replica of `GetFullName`, including the behavior where `game` is excluded from the full name.