### PR TITLE
Mark instances correctly as creatable or not correctly.

### DIFF
--- a/lib/Habitat.lua
+++ b/lib/Habitat.lua
@@ -7,6 +7,7 @@
 local Instance = import("./Instance")
 local environment = import("./environment")
 local fs = import("./fs")
+local Game = import("./instances/Game")
 
 local Habitat = {}
 Habitat.__index = Habitat
@@ -17,7 +18,7 @@ function Habitat.new(settings)
 		settings = settings or {},
 	}
 
-	habitat.game = Instance.new("Game")
+	habitat.game = Game:new()
 
 	setmetatable(habitat, Habitat)
 

--- a/lib/instances/BaseInstance.lua
+++ b/lib/instances/BaseInstance.lua
@@ -20,7 +20,7 @@ end
 local BaseInstance = {}
 
 BaseInstance.options = {
-	creatable = true,
+	creatable = false,
 }
 
 BaseInstance.name = "Instance"

--- a/lib/instances/BaseInstance_spec.lua
+++ b/lib/instances/BaseInstance_spec.lua
@@ -1,8 +1,8 @@
-local BaseInstance = import("./BaseInstance")
-
 local Game = import("./Game")
 local Folder = import("./Folder")
 local typeof = import("../functions/typeof")
+
+local BaseInstance = import("./BaseInstance")
 
 describe("instances.BaseInstance", function()
 	it("should error when parenting instances to invalid objects", function()

--- a/lib/instances/BindableEvent.lua
+++ b/lib/instances/BindableEvent.lua
@@ -2,7 +2,9 @@ local Signal = import("../Signal")
 local BaseInstance = import("./BaseInstance")
 local InstanceProperty = import("../InstanceProperty")
 
-local BindableEvent = BaseInstance:extend("BindableEvent")
+local BindableEvent = BaseInstance:extend("BindableEvent", {
+	creatable = true,
+})
 
 BindableEvent.properties.Event = InstanceProperty.readOnly({
 	getDefault = Signal.new,

--- a/lib/instances/BoolValue.lua
+++ b/lib/instances/BoolValue.lua
@@ -1,7 +1,9 @@
 local BaseInstance = import("./BaseInstance")
 local InstanceProperty = import("../InstanceProperty")
 
-local BoolValue = BaseInstance:extend("BoolValue")
+local BoolValue = BaseInstance:extend("BoolValue", {
+	creatable = true,
+})
 
 BoolValue.properties.Value = InstanceProperty.normal({
 	getDefault = function()

--- a/lib/instances/Camera.lua
+++ b/lib/instances/Camera.lua
@@ -2,7 +2,9 @@ local BaseInstance = import("./BaseInstance")
 local Vector2 = import("../types/Vector2")
 local InstanceProperty = import("../InstanceProperty")
 
-local Camera = BaseInstance:extend("Camera")
+local Camera = BaseInstance:extend("Camera", {
+	creatable = true,
+})
 
 Camera.properties.ViewportSize = InstanceProperty.normal({
 	getDefault = function()

--- a/lib/instances/Camera_spec.lua
+++ b/lib/instances/Camera_spec.lua
@@ -1,15 +1,15 @@
-local Camera = import("./Camera")
+local Instance = import("../Instance")
 local typeof = import("../functions/typeof")
 
 describe("instances.Camera", function()
 	it("should instantiate", function()
-		local instance = Camera:new()
+		local instance = Instance.new("Camera")
 
 		assert.not_nil(instance)
 	end)
 
 	it("should have properties defined", function()
-		local instance = Camera:new()
+		local instance = Instance.new("Camera")
 		assert.equal(typeof(instance.ViewportSize), "Vector2")
 	end)
 end)

--- a/lib/instances/ContentProvider_spec.lua
+++ b/lib/instances/ContentProvider_spec.lua
@@ -1,14 +1,14 @@
-local Instance = import("../Instance")
+local ContentProvider = import("./ContentProvider")
 
 describe("instances.ContentProvider", function()
 	it("should instantiate", function()
-		local instance = Instance.new("ContentProvider")
+		local instance = ContentProvider:new()
 
 		assert.not_nil(instance)
 	end)
 
 	it("should have a string property BaseUrl", function()
-		local instance = Instance.new("ContentProvider")
+		local instance = ContentProvider:new()
 
 		assert.equals(type(instance.BaseUrl), "string")
 	end)

--- a/lib/instances/CoreGui_spec.lua
+++ b/lib/instances/CoreGui_spec.lua
@@ -1,9 +1,8 @@
 local CoreGui = import("./CoreGui")
-local Instance = import("../Instance")
 
 describe("instances.CoreGui", function()
 	it("should instantiate", function()
-		local instance = Instance.new("CoreGui")
+		local instance = CoreGui:new()
 
 		assert.not_nil(instance)
 	end)

--- a/lib/instances/Folder.lua
+++ b/lib/instances/Folder.lua
@@ -1,3 +1,5 @@
 local BaseInstance = import("./BaseInstance")
 
-return BaseInstance:extend("Folder")
+return BaseInstance:extend("Folder", {
+	creatable = true,
+})

--- a/lib/instances/Frame.lua
+++ b/lib/instances/Frame.lua
@@ -1,3 +1,5 @@
 local GuiObject = import("./GuiObject")
 
-return GuiObject:extend("Frame")
+return GuiObject:extend("Frame", {
+	creatable = true,
+})

--- a/lib/instances/Game.lua
+++ b/lib/instances/Game.lua
@@ -1,28 +1,43 @@
 local BaseInstance = import("./BaseInstance")
 
+local AnalyticsService = import("./AnalyticsService")
+local ContentProvider = import("./ContentProvider")
+local CoreGui = import("./CoreGui")
+local GuiService = import("./GuiService")
+local HttpService = import("./HttpService")
+local LocalizationService = import("./LocalizationService")
+local NotificationService = import("./NotificationService")
+local Players = import("./Players")
+local ReplicatedStorage = import("./ReplicatedStorage")
+local RunService = import("./RunService")
+local Stats = import("./Stats")
+local TestService = import("./TestService")
+local TextService = import("./TextService")
+local TweenService = import("./TweenService")
+local UserInputService = import("./UserInputService")
+local VirtualInputManager = import("./VirtualInputManager")
+local Workspace = import("./Workspace")
+
 local Game = BaseInstance:extend("DataModel")
 
 function Game:init(instance)
-	-- Late import here to avoid a circular reference
-	local Instance = import("../Instance")
-
-	Instance.new("AnalyticsService", instance)
-	Instance.new("ContentProvider", instance)
-	Instance.new("CoreGui", instance)
-	Instance.new("GuiService", instance)
-	Instance.new("HttpService", instance)
-	Instance.new("LocalizationService", instance)
-	Instance.new("NotificationService", instance)
-	Instance.new("Players", instance)
-	Instance.new("RunService", instance)
-	Instance.new("ReplicatedStorage", instance)
-	Instance.new("Stats", instance)
-	Instance.new("TestService", instance)
-	Instance.new("TextService", instance)
-	Instance.new("TweenService", instance)
-	Instance.new("UserInputService", instance)
-	Instance.new("VirtualInputManager", instance)
-	Instance.new("Workspace", instance)
+	AnalyticsService:new().Parent = instance
+	ContentProvider:new().Parent = instance
+	CoreGui:new().Parent = instance
+	GuiService:new().Parent = instance
+	HttpService:new().Parent = instance
+	LocalizationService:new().Parent = instance
+	NotificationService:new().Parent = instance
+	Players:new().Parent = instance
+	ReplicatedStorage:new().Parent = instance
+	RunService:new().Parent = instance
+	Stats:new().Parent = instance
+	TestService:new().Parent = instance
+	TextService:new().Parent = instance
+	TweenService:new().Parent = instance
+	UserInputService:new().Parent = instance
+	VirtualInputManager:new().Parent = instance
+	Workspace:new().Parent = instance
 end
 
 function Game.prototype:GetService(serviceName)

--- a/lib/instances/Game_spec.lua
+++ b/lib/instances/Game_spec.lua
@@ -1,9 +1,8 @@
 local Game = import("./Game")
-local Instance = import("../Instance")
 
 describe("instances.Game", function()
 	it("should instantiate", function()
-		local instance = Instance.new("Game")
+		local instance = Game:new()
 
 		assert.not_nil(instance)
 	end)

--- a/lib/instances/GuiButton_spec.lua
+++ b/lib/instances/GuiButton_spec.lua
@@ -1,15 +1,16 @@
-local Instance = import("../Instance")
 local typeof = import("../functions/typeof")
+
+local GuiButton = import("./GuiButton")
 
 describe("instances.GuiButton", function()
 	it("should instantiate", function()
-		local instance = Instance.new("GuiButton")
+		local instance = GuiButton:new()
 
 		assert.not_nil(instance)
 	end)
 
 	it("should have properties defined", function()
-		local instance = Instance.new("GuiButton")
+		local instance = GuiButton:new()
 		assert.equal(typeof(instance.Activated), "RBXScriptSignal")
 		assert.equal(typeof(instance.AutoButtonColor), "boolean")
 		assert.equal(typeof(instance.MouseButton1Click), "RBXScriptSignal")

--- a/lib/instances/HttpService_spec.lua
+++ b/lib/instances/HttpService_spec.lua
@@ -1,22 +1,20 @@
-local Instance = import("../Instance")
+local HttpService = import("./HttpService")
 
 describe("instances.HttpService", function()
 	it("should instantiate", function()
-		local instance = Instance.new("IntValue")
+		local instance = HttpService:new()
 
 		assert.not_nil(instance)
-		assert.equal("Value", instance.Name)
-		assert.equal(0, instance.Value)
 	end)
 
 	it("should json encode properly", function()
-		local instance = Instance.new("HttpService")
+		local instance = HttpService:new()
 
 		assert.equal(instance:JSONEncode({ 1, true }), "[1,true]")
 	end)
 
 	it("should json decode properly", function()
-		local instance = Instance.new("HttpService")
+		local instance = HttpService:new()
 
 		assert.are.same(instance:JSONDecode("[1,true]"), { 1, true })
 	end)

--- a/lib/instances/ImageButton.lua
+++ b/lib/instances/ImageButton.lua
@@ -3,7 +3,10 @@ local Enum = import("../Enum")
 local GuiButton = import("./GuiButton")
 local InstanceProperty = import("../InstanceProperty")
 local Rect = import("../types/Rect")
-local ImageButton = GuiButton:extend("ImageButton")
+
+local ImageButton = GuiButton:extend("ImageButton", {
+	creatable = true,
+})
 
 ImageButton.properties.Image = InstanceProperty.typed("string", {
 	getDefault = function()

--- a/lib/instances/ImageLabel.lua
+++ b/lib/instances/ImageLabel.lua
@@ -3,7 +3,10 @@ local Enum = import("../Enum")
 local GuiObject = import("./GuiObject")
 local InstanceProperty = import("../InstanceProperty")
 local Rect = import("../types/Rect")
-local ImageLabel = GuiObject:extend("ImageLabel")
+
+local ImageLabel = GuiObject:extend("ImageLabel", {
+	creatable = true,
+})
 
 ImageLabel.properties.Image = InstanceProperty.typed("string", {
 	getDefault = function()

--- a/lib/instances/IntValue.lua
+++ b/lib/instances/IntValue.lua
@@ -1,16 +1,18 @@
 local BaseInstance = import("./BaseInstance")
 local InstanceProperty = import("../InstanceProperty")
 
-local StringValue = BaseInstance:extend("StringValue")
+local IntValue = BaseInstance:extend("IntValue", {
+	creatable = true,
+})
 
-StringValue.properties.Value = InstanceProperty.normal({
+IntValue.properties.Value = InstanceProperty.normal({
 	getDefault = function()
 		return 0
 	end,
 })
 
-function StringValue:init(instance)
+function IntValue:init(instance)
 	instance.Name = "Value"
 end
 
-return StringValue
+return IntValue

--- a/lib/instances/LocalScript.lua
+++ b/lib/instances/LocalScript.lua
@@ -5,7 +5,9 @@
 local BaseInstance = import("./BaseInstance")
 local InstanceProperty = import("../InstanceProperty")
 
-local LocalScript = BaseInstance:extend("LocalScript")
+local LocalScript = BaseInstance:extend("LocalScript", {
+	creatable = true,
+})
 
 LocalScript.properties.Source = InstanceProperty.normal({
 	getDefault = function()

--- a/lib/instances/LocalizationService_spec.lua
+++ b/lib/instances/LocalizationService_spec.lua
@@ -1,21 +1,21 @@
-local Instance = import("../Instance")
+local LocalizationService = import("./LocalizationService")
 
 describe("instances.LocalizationService", function()
 	it("should instantiate", function()
-		local instance = Instance.new("LocalizationService")
+		local instance = LocalizationService:new()
 
 		assert.not_nil(instance)
 	end)
 
 	describe("SystemLocaleId", function()
 		it("should have a string value", function()
-			local instance = Instance.new("LocalizationService")
+			local instance = LocalizationService:new()
 			assert.not_nil(instance.SystemLocaleId)
 			assert.equals(type(instance.SystemLocaleId), "string")
 		end)
 
 		it("should be read-only", function()
-			local instance = Instance.new("LocalizationService")
+			local instance = LocalizationService:new()
 			assert.has.errors(function()
 				instance.SystemLocaleId = "es-mx"
 			end)
@@ -24,13 +24,13 @@ describe("instances.LocalizationService", function()
 
 	describe("RobloxLocaleId", function()
 		it("should have a string value", function()
-			local instance = Instance.new("LocalizationService")
+			local instance = LocalizationService:new()
 			assert.not_nil(instance.RobloxLocaleId)
 			assert.equals(type(instance.RobloxLocaleId), "string")
 		end)
 
 		it("should be read-only", function()
-			local instance = Instance.new("LocalizationService")
+			local instance = LocalizationService:new()
 			assert.has.errors(function()
 				instance.RobloxLocaleId = "es-mx"
 			end)

--- a/lib/instances/LocalizationTable.lua
+++ b/lib/instances/LocalizationTable.lua
@@ -2,7 +2,9 @@ local BaseInstance = import("./BaseInstance")
 local InstanceProperty = import("../InstanceProperty")
 local json = import("../json")
 
-local LocalizationTable = BaseInstance:extend("LocalizationTable")
+local LocalizationTable = BaseInstance:extend("LocalizationTable", {
+	creatable = true,
+})
 
 LocalizationTable.properties.SourceLocaleId = InstanceProperty.normal({
 	getDefault = function()

--- a/lib/instances/ModuleScript.lua
+++ b/lib/instances/ModuleScript.lua
@@ -1,7 +1,9 @@
 local BaseInstance = import("./BaseInstance")
 local InstanceProperty = import("../InstanceProperty")
 
-local ModuleScript = BaseInstance:extend("ModuleScript")
+local ModuleScript = BaseInstance:extend("ModuleScript", {
+	creatable = true,
+})
 
 ModuleScript.properties.Source = InstanceProperty.normal({
 	getDefault = function()

--- a/lib/instances/NotificationService.lua
+++ b/lib/instances/NotificationService.lua
@@ -1,4 +1,5 @@
 local BaseInstance = import("./BaseInstance")
-local NotificationService = BaseInstance:extend("NotificationService")
 
-return NotificationService
+return BaseInstance:extend("NotificationService", {
+	creatable = true,
+})

--- a/lib/instances/ObjectValue.lua
+++ b/lib/instances/ObjectValue.lua
@@ -1,7 +1,9 @@
 local BaseInstance = import("./BaseInstance")
 local InstanceProperty = import("../InstanceProperty")
 
-local ObjectValue = BaseInstance:extend("ObjectValue")
+local ObjectValue = BaseInstance:extend("ObjectValue", {
+	creatable = true,
+})
 
 ObjectValue.properties.Value = InstanceProperty.normal({})
 

--- a/lib/instances/Players_spec.lua
+++ b/lib/instances/Players_spec.lua
@@ -1,15 +1,16 @@
-local Instance = import("../Instance")
 local typeof = import("../functions/typeof")
+
+local Players = import("./Players")
 
 describe("instances.Players", function()
 	it("should instantiate", function()
-		local instance = Instance.new("Players")
+		local instance = Players:new()
 
 		assert.not_nil(instance)
 	end)
 
 	it("should have properties defined", function()
-		local instance = Instance.new("Players")
+		local instance = Players:new()
 
 		assert.equal(typeof(instance.LocalPlayer), "Instance")
 	end)

--- a/lib/instances/ReplicatedStorage_spec.lua
+++ b/lib/instances/ReplicatedStorage_spec.lua
@@ -1,8 +1,8 @@
-local Instance = import("../Instance")
+local ReplicatedStorage = import("./ReplicatedStorage")
 
 describe("instances.ReplicatedStorage", function()
 	it("should instantiate", function()
-		local instance = Instance.new("ReplicatedStorage")
+		local instance = ReplicatedStorage:new()
 
 		assert.not_nil(instance)
 	end)

--- a/lib/instances/ScreenGui.lua
+++ b/lib/instances/ScreenGui.lua
@@ -2,7 +2,9 @@ local BaseInstance = import("./BaseInstance")
 local InstanceProperty = import("../InstanceProperty")
 local Vector2 = import("../types/Vector2")
 
-local ScreenGui = BaseInstance:extend("ScreenGui")
+local ScreenGui = BaseInstance:extend("ScreenGui", {
+	creatable = true,
+})
 
 ScreenGui.properties.AbsoluteSize = InstanceProperty.readOnly({
 	get = function(self)

--- a/lib/instances/ScreenGui_spec.lua
+++ b/lib/instances/ScreenGui_spec.lua
@@ -1,27 +1,27 @@
-local ScreenGui = import("./ScreenGui")
+local Instance = import("../Instance")
 local typeof = import("../functions/typeof")
 
 describe("instances.ScreenGui", function()
 	it("should instantiate", function()
-		local instance = ScreenGui:new()
+		local instance = Instance.new("ScreenGui")
 
 		assert.not_nil(instance)
 	end)
 
 	describe("DisplayOrder", function()
 		it("should have a value that is a number", function()
-			local instance = ScreenGui:new()
+			local instance = Instance.new("ScreenGui")
 			assert.equals(type(instance.DisplayOrder), "number")
 		end)
 
 		it("should be settable", function()
-			local instance = ScreenGui:new()
+			local instance = Instance.new("ScreenGui")
 			instance.DisplayOrder = 2
 			assert.equals(instance.DisplayOrder, 2)
 		end)
 
 		it("should only accept numbers", function()
-			local instance = ScreenGui:new()
+			local instance = Instance.new("ScreenGui")
 			assert.has.errors(function()
 				instance.DisplayOrder = "string"
 			end)
@@ -30,7 +30,7 @@ describe("instances.ScreenGui", function()
 
 	describe("AbsoluteSize", function()
 		it("should return a Vector2", function()
-			local instance = ScreenGui:new()
+			local instance = Instance.new("ScreenGui")
 			assert.equals(typeof(instance.AbsoluteSize), "Vector2")
 		end)
 	end)

--- a/lib/instances/Script.lua
+++ b/lib/instances/Script.lua
@@ -5,7 +5,9 @@
 local BaseInstance = import("./BaseInstance")
 local InstanceProperty = import("../InstanceProperty")
 
-local Script = BaseInstance:extend("Script")
+local Script = BaseInstance:extend("Script", {
+	creatable = true,
+})
 
 Script.properties.Source = InstanceProperty.normal({
 	getDefault = function()

--- a/lib/instances/Stats_spec.lua
+++ b/lib/instances/Stats_spec.lua
@@ -1,8 +1,8 @@
-local Instance = import("../Instance")
+local Stats = import("./Stats")
 
 describe("instances.Stats", function()
 	it("should instantiate", function()
-		local instance = Instance.new("Stats")
+		local instance = Stats:new()
 
 		assert.not_nil(instance)
 	end)

--- a/lib/instances/StringValue.lua
+++ b/lib/instances/StringValue.lua
@@ -1,7 +1,9 @@
 local BaseInstance = import("./BaseInstance")
 local InstanceProperty = import("../InstanceProperty")
 
-local StringValue = BaseInstance:extend("StringValue")
+local StringValue = BaseInstance:extend("StringValue", {
+	creatable = true,
+})
 
 StringValue.properties.Value = InstanceProperty.normal({
 	getDefault = function()

--- a/lib/instances/TestService_spec.lua
+++ b/lib/instances/TestService_spec.lua
@@ -1,15 +1,15 @@
-local Instance = import("../Instance")
+local TestService = import("./TestService")
 
 describe("instances.TestService", function()
 	it("should instantiate", function()
-		local instance = Instance.new("TestService")
+		local instance = TestService:new()
 
 		assert.not_nil(instance)
 		assert.not_nil(instance.Error)
 	end)
 
 	it("should write to stderr", function()
-		local instance = Instance.new("TestService")
+		local instance = TestService:new()
 		local oldErr = io.stderr
 
 		local writeSpy = spy.new(function(_, msg) end)

--- a/lib/instances/TextButton.lua
+++ b/lib/instances/TextButton.lua
@@ -1,7 +1,10 @@
 local Color3 = import("../types/Color3")
 local GuiButton = import("./GuiButton")
 local InstanceProperty = import("../InstanceProperty")
-local TextButton = GuiButton:extend("TextButton")
+
+local TextButton = GuiButton:extend("TextButton", {
+	creatable = true,
+})
 
 TextButton.properties.Text = InstanceProperty.typed("string", {
 	getDefault = function()

--- a/lib/instances/TextLabel.lua
+++ b/lib/instances/TextLabel.lua
@@ -2,7 +2,10 @@ local Color3 = import("../types/Color3")
 local Enum = import("../Enum")
 local GuiObject = import("./GuiObject")
 local InstanceProperty = import("../InstanceProperty")
-local TextLabel = GuiObject:extend("TextLabel")
+
+local TextLabel = GuiObject:extend("TextLabel", {
+	creatable = true,
+})
 
 TextLabel.properties.Font = InstanceProperty.typed("number", {
 	getDefault = function()

--- a/lib/instances/TextService_spec.lua
+++ b/lib/instances/TextService_spec.lua
@@ -1,18 +1,19 @@
-local Instance = import("../Instance")
 local Enum = import("../Enum")
 local Vector2 = import("../types/Vector2")
 local typeof = import("../functions/typeof")
 
+local TextService = import("./TextService")
+
 describe("instances.TextService", function()
 	it("should instantiate", function()
-		local instance = Instance.new("TextService")
+		local instance = TextService:new()
 
 		assert.not_nil(instance)
 	end)
 
 	describe("GetTextSize", function()
 		it("should verify parameters", function()
-			local instance = Instance.new("TextService")
+			local instance = TextService:new()
 
 			assert.has.errors(function()
 				instance:GetTextSize(100, 36, Enum.Font.Legacy, Vector2.new(1, 1))
@@ -29,14 +30,14 @@ describe("instances.TextService", function()
 		end)
 
 		it("should return a Vector2", function()
-			local instance = Instance.new("TextService")
+			local instance = TextService:new()
 			local result = instance:GetTextSize("text", 36, Enum.Font.Legacy, Vector2.new(1000, 1000))
 
 			assert.equals(typeof(result), "Vector2")
 		end)
 
 		it("should clip the rect down", function()
-			local instance = Instance.new("TextService")
+			local instance = TextService:new()
 			local result = instance:GetTextSize("VERY LARGE TEXT", 36, Enum.Font.Legacy, Vector2.new(1, 1))
 
 			assert.same({result.X, result.Y}, {1, 1})

--- a/lib/instances/TweenService.lua
+++ b/lib/instances/TweenService.lua
@@ -1,4 +1,3 @@
 local BaseInstance = import("./BaseInstance")
-local TweenService = BaseInstance:extend("TweenService")
 
-return TweenService
+return BaseInstance:extend("TweenService")

--- a/lib/instances/TweenService_spec.lua
+++ b/lib/instances/TweenService_spec.lua
@@ -1,8 +1,8 @@
-local Instance = import("../Instance")
+local TweenService = import("./TweenService")
 
 describe("instances.TweenService", function()
 	it("should instantiate", function()
-		local instance = Instance.new("TweenService")
+		local instance = TweenService:new()
 
 		assert.not_nil(instance)
 	end)

--- a/lib/instances/UIGridStyleLayout.lua
+++ b/lib/instances/UIGridStyleLayout.lua
@@ -1,6 +1,7 @@
 local Enum = import("../Enum")
 local BaseInstance = import("./BaseInstance")
 local InstanceProperty = import("../InstanceProperty")
+
 local UIGridStyleLayout = BaseInstance:extend("UIGridStyleLayout")
 
 UIGridStyleLayout.properties.HorizontalAlignment = InstanceProperty.typed("number", {

--- a/lib/instances/UIGridStyleLayout_spec.lua
+++ b/lib/instances/UIGridStyleLayout_spec.lua
@@ -1,5 +1,6 @@
-local UIGridStyleLayout = import("./UIGridStyleLayout")
 local typeof = import("../functions/typeof")
+
+local UIGridStyleLayout = import("./UIGridStyleLayout")
 
 describe("instances.UIGridStyleLayout", function()
 	it("should instantiate", function()

--- a/lib/instances/UIListLayout.lua
+++ b/lib/instances/UIListLayout.lua
@@ -1,7 +1,10 @@
 local UIGridStyleLayout = import("./UIGridStyleLayout")
 local InstanceProperty = import("../InstanceProperty")
 local UDim = import("../types/UDim")
-local UIListLayout = UIGridStyleLayout:extend("UIListLayout")
+
+local UIListLayout = UIGridStyleLayout:extend("UIListLayout", {
+	creatable = true,
+})
 
 UIListLayout.properties.Padding = InstanceProperty.typed("UDim", {
 	getDefault = function()

--- a/lib/instances/UIListLayout_spec.lua
+++ b/lib/instances/UIListLayout_spec.lua
@@ -1,21 +1,21 @@
-local UIListLayout = import("./UIListLayout")
+local Instance = import("../Instance")
 local typeof = import("../functions/typeof")
 
 describe("instances.UIListLayout", function()
 	it("should instantiate", function()
-		local instance = UIListLayout:new()
+		local instance = Instance.new("UIListLayout")
 
 		assert.not_nil(instance)
 	end)
 
 	it("should inherit from UIGridStyleLayout", function()
-		local instance = UIListLayout:new()
+		local instance = Instance.new("UIListLayout")
 
 		assert.True(instance:IsA("UIGridStyleLayout"))
 	end)
 
 	it("should have properties defined", function()
-		local instance = UIListLayout:new()
+		local instance = Instance.new("UIListLayout")
 
 		assert.equals(typeof(instance.Padding), "UDim")
 	end)

--- a/lib/instances/UIPadding.lua
+++ b/lib/instances/UIPadding.lua
@@ -1,7 +1,10 @@
 local BaseInstance = import("./BaseInstance")
 local InstanceProperty = import("../InstanceProperty")
 local UDim = import("../types/UDim")
-local UIPadding = BaseInstance:extend("UIPadding")
+
+local UIPadding = BaseInstance:extend("UIPadding", {
+	creatable = true,
+})
 
 UIPadding.properties.PaddingBottom = InstanceProperty.typed("UDim", {
 	getDefault = function()

--- a/lib/instances/UserInputService.lua
+++ b/lib/instances/UserInputService.lua
@@ -1,4 +1,3 @@
 local BaseInstance = import("./BaseInstance")
-local UserInputService = BaseInstance:extend("UserInputService")
 
-return UserInputService
+return BaseInstance:extend("UserInputService")

--- a/lib/instances/UserInputService_spec.lua
+++ b/lib/instances/UserInputService_spec.lua
@@ -1,8 +1,8 @@
-local Instance = import("../Instance")
+local UserInputService = import("./UserInputService")
 
 describe("instances.UserInputService", function()
 	it("should instantiate", function()
-		local instance = Instance.new("UserInputService")
+		local instance = UserInputService:new()
 
 		assert.not_nil(instance)
 	end)

--- a/lib/instances/VirtualInputManager.lua
+++ b/lib/instances/VirtualInputManager.lua
@@ -1,2 +1,3 @@
 local BaseInstance = import("./BaseInstance")
+
 return BaseInstance:extend("VirtualInputManager")

--- a/lib/instances/Workspace.lua
+++ b/lib/instances/Workspace.lua
@@ -1,6 +1,7 @@
 local BaseInstance = import("./BaseInstance")
 local Camera = import("./Camera")
 local InstanceProperty = import("../InstanceProperty")
+
 local Workspace = BaseInstance:extend("Workspace")
 
 function Workspace:init(instance)

--- a/lib/instances/Workspace_spec.lua
+++ b/lib/instances/Workspace_spec.lua
@@ -1,24 +1,26 @@
-local Instance = import("../Instance")
+local Workspace = import("./Workspace")
 local typeof = import("../functions/typeof")
 
 describe("instances.Workspace", function()
 	it("should instantiate", function()
-		local instance = Instance.new("Workspace")
+		local instance = Workspace:new()
 
 		assert.not_nil(instance)
 	end)
 
 	describe("CurrentCamera", function()
 		it("should be an object of type Camera", function()
-			local instance = Instance.new("Workspace")
+			local instance = Workspace:new()
 			local camera = instance.CurrentCamera
+
 			assert.not_nil(camera)
 			assert.equal(typeof(camera), "Instance")
 		end)
 
 		it("should be accessible as a child named Camera", function()
-			local instance = Instance.new("Workspace")
+			local instance = Workspace:new()
 			local camera = instance:WaitForChild("Camera")
+
 			assert.not_nil(camera)
 			assert.equals(instance.CurrentCamera, camera)
 		end)


### PR DESCRIPTION
Closes #13.

This PR was borne out of flipping `BaseInstance` `creatable` to `false` and stepping through all of the tests one by one.

This prevents erroneously creating services using Instance.new, but
required a comprehensive review of every test that touches instances.

This establishes a new ad-hoc convention: for any instances that are
creatable, create them using Instance.new and include a test that does
just that. For instances that are not, import their module directly and
use Foo:new().