### PR TITLE
Make Script schedule itself to run when parented to a DataModel

### DIFF
--- a/lib/instances/Game.lua
+++ b/lib/instances/Game.lua
@@ -21,7 +21,7 @@ local Workspace = import("./Workspace")
 
 local Game = BaseInstance:extend("DataModel")
 
-function Game:init(instance)
+function Game:init(instance, habitat)
 	AnalyticsService:new().Parent = instance
 	ContentProvider:new().Parent = instance
 	CoreGui:new().Parent = instance
@@ -40,6 +40,8 @@ function Game:init(instance)
 	UserInputService:new().Parent = instance
 	VirtualInputManager:new().Parent = instance
 	Workspace:new().Parent = instance
+
+	getmetatable(instance).instance.habitat = habitat
 end
 
 function Game.prototype:GetService(serviceName)

--- a/lib/instances/LocalScript.lua
+++ b/lib/instances/LocalScript.lua
@@ -1,18 +1,9 @@
 --[[
-	Serves as just a source container right now.
+	Currently exactly the same as Script.
 ]]
 
-local BaseInstance = import("./BaseInstance")
-local InstanceProperty = import("../InstanceProperty")
+local Script = import("./Script")
 
-local LocalScript = BaseInstance:extend("LocalScript", {
-	creatable = true,
-})
-
-LocalScript.properties.Source = InstanceProperty.normal({
-	getDefault = function()
-		return ""
-	end,
-})
+local LocalScript = Script:extend("LocalScript")
 
 return LocalScript

--- a/lib/instances/Script.lua
+++ b/lib/instances/Script.lua
@@ -9,6 +9,41 @@ local Script = BaseInstance:extend("Script", {
 	creatable = true,
 })
 
+function Script:init(instance)
+	local internal = getmetatable(instance).instance
+
+	internal.hasRun = false
+
+	instance.AncestryChanged:Connect(function()
+		if internal.hasRun then
+			return
+		end
+
+		local game = nil
+
+		local now = instance
+		while now do
+			now = now.Parent
+
+			if now.ClassName == "DataModel" then
+				game = now
+				break
+			end
+		end
+
+		if game == nil then
+			return
+		end
+
+		internal.hasRun = true
+
+		-- TODO: Correctly handle errors
+
+		local co = coroutine.create(loadstring(instance.Source))
+		getmetatable(game).instance.habitat.taskScheduler:schedule(0, co)
+	end)
+end
+
 Script.properties.Source = InstanceProperty.normal({
 	getDefault = function()
 		return ""


### PR DESCRIPTION
This PR takes advantage of the new task scheduler to cause `Script` (and now `LocalScript`) objects to schedule themselves to execute when parented to a `DataModel`.

This logic is right now sort of shaky. I'm not confident that it's correct right now.

Things to do before merge:
* [ ] Verify that this behavior (scripts begin executing when parented) is correct
* [ ] Figure out whether scripts should push a task into the scheduler or immediately run
* [ ] Handle error cases correctly:
    * [ ] Parsing errors
    * [ ] Runtime errors before the initial yield, which is the job of the initial caller if not using the task scheduler
* [ ] Add a method here or in a future PR to explicitly start stepping through all tasks, including scripts