### PR TITLE
WIP: Implement HttpService:RequestAsync

### DIFF
--- a/lib/http.lua
+++ b/lib/http.lua
@@ -1,15 +1,15 @@
-local exists, http = pcall(require, "socket.http")
+local httpExists, socketHttp = pcall(require, "socket.http")
+local ltn12Exists, ltn12 = pcall(require, "ltn12")
 
-local httpShim = {}
+local http = {}
 
-function httpShim.get(url)
+function http.request()
 	error("Please install `luasocket` to use HTTP features.", 2)
 end
 
-if exists then
-	function httpShim.get(url)
-		return (http.request(url))
-	end
+if httpExists and ltn12Exists then
+	http.request = socketHttp.request
+	http.tableSink = ltn12.sink.table
 end
 
-return httpShim
+return http

--- a/lib/instances/Game.lua
+++ b/lib/instances/Game.lua
@@ -1,3 +1,4 @@
+local http = import("../http")
 local BaseInstance = import("./BaseInstance")
 
 local AnalyticsService = import("./AnalyticsService")
@@ -27,7 +28,7 @@ function Game:init(instance)
 	CoreGui:new().Parent = instance
 	CorePackages:new().Parent = instance
 	GuiService:new().Parent = instance
-	HttpService:new().Parent = instance
+	HttpService:new(http).Parent = instance
 	LocalizationService:new().Parent = instance
 	NotificationService:new().Parent = instance
 	Players:new().Parent = instance

--- a/lib/instances/HttpService.lua
+++ b/lib/instances/HttpService.lua
@@ -1,8 +1,12 @@
 local BaseInstance = import("./BaseInstance")
 local json = import("../json")
-local http = import("../http")
 
 local HttpService = BaseInstance:extend("HttpService")
+
+function HttpService:init(instance, httpImpl)
+	local internalInstance = getmetatable(instance).instance
+	internalInstance.httpImpl = httpImpl
+end
 
 function HttpService.prototype:JSONEncode(input)
 	return json.encode(input)
@@ -12,8 +16,68 @@ function HttpService.prototype:JSONDecode(input)
 	return json.decode(input)
 end
 
-function HttpService.prototype:GetAsync(url)
-	return http.get(url)
+function HttpService.prototype:RequestAsync(options)
+	local internalInstance = getmetatable(self).instance
+	local httpImpl = internalInstance.httpImpl
+
+	if type(options) ~= "table" then
+		error(("Bad argument #1 to RequestAsync: expected table, found %s"):format(type(options)), 2)
+	end
+
+	local url = options.Url
+	local method = options.Method
+	local headers = options.Headers
+	local body = options.body
+
+	if type(url) ~= "string" then
+		error(("Option `Url` must be a string, but it was a %s"):format(type(url)), 2)
+	end
+
+	if method ~= nil and type(method) ~= "string" then
+		error(("Option `Method` must be a string or nil, but it was a %s"):format(type(url)), 2)
+	end
+
+	if headers ~= nil and type(headers) ~= "table" then
+		error(("Option `Headers` must be a table or nil, but it was a %s"):format(type(url)), 2)
+	end
+
+	if body ~= nil and type(body) ~= "string" then
+		error(("Option `Body` must be a string or nil, but it was a %s"):format(type(url)), 2)
+	end
+
+	if headers == nil then
+		headers = {}
+	end
+
+	if body ~= nil then
+		headers["Content-Length"] = #body
+	end
+
+	local responseBody = {}
+
+	local _, statusCode, responseHeaders = httpImpl.request({
+		url = url,
+		sink = httpImpl.tableSink(responseBody),
+		method = method,
+		headers = headers,
+		source = body,
+	})
+
+	return {
+		Success = statusCode >= 200 and statusCode <= 399,
+		StatusCode = statusCode,
+		StatusMessage = "uhhh",
+		Headers = responseHeaders,
+		Body = table.concat(responseBody),
+	}
+end
+
+function HttpService.prototype:GetAsync()
+	error("GetAsync is not implemented by Lemur -- use RequestAsync instead.", 2)
+end
+
+function HttpService.prototype:PostAsync()
+	error("PostAsync is not implemented by Lemur -- use RequestAsync instead.", 2)
 end
 
 return HttpService

--- a/lib/instances/HttpService_spec.lua
+++ b/lib/instances/HttpService_spec.lua
@@ -18,4 +18,23 @@ describe("instances.HttpService", function()
 
 		assert.are.same(instance:JSONDecode("[1,true]"), { 1, true })
 	end)
+
+	it("should send HTTP requests", function()
+		local httpImpl = {
+			request = function()
+				return 1, 200, {}
+			end,
+			tableSink = function()
+				return {}
+			end,
+		}
+
+		local instance = HttpService:new(httpImpl)
+
+		local response = instance:RequestAsync({
+			Url = "https://google.com/",
+		})
+
+		print(response.Body)
+	end)
 end)


### PR DESCRIPTION
Closes #101.

This PR implements a real version of `HttpService:RequestAsync` using LuaSocket's `socket.http` and `ltn12` modules.

`HttpService` can also be constructed using a fake HTTP implementation, which is useful for testing `HttpService` itself, but may also be useful for consumers of Lemur. Before merging this, perhaps I should also add a configuration option to habitats to disable real HTTP requests or make them cause errors.

Merge checklist:
* [ ] Finish tests
* [ ] Changelog and FEATURES entries
* [ ] Real world test (Rojo integration tests)