### PR TITLE
Fix loadFromFs erroring when browsing directories with non lua files in

### DIFF
--- a/lib/Habitat.lua
+++ b/lib/Habitat.lua
@@ -55,6 +55,8 @@ function Habitat:loadFromFs(path, passedOptions)
 
 			return instance
 		end
+		-- Ignore non-lua files
+		return
 	elseif fs.isDirectory(path) then
 		local instance = Instance.new("Folder")
 		instance.Name = path:match("([^/]-)$")


### PR DESCRIPTION
Currently the code on master will throw if you try to loadFromFs("dir") and dir contains e.g. `dir/someFile.md`