### PR TITLE
Add bit32 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
   - luarocks install luacheck
   - luarocks install luafilesystem
   - luarocks install dkjson
+  - luarocks install bit32
 
 script:
   - luacheck lib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * `RunService` is now correctly named `Run Service` ([#25](https://github.com/LPGhatguy/lemur/pull/25))
 * Added `Instance:FindFirstChildOfClass(name)` and `Instance:FindFirstChildWhichIsA(className)`
 * Changed `Signal:Wait()` mechanism to error instead of fire the event
+* Added `bit32`; requires `bit32` luarock to be installed
 
 ## v0.1.0 (November 28, 2017)
 * Initial release

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -35,6 +35,7 @@ This document should remain up-to-date with current API coverage and status.
 * typeof
 * wait (stub)
 * warn
+* bit32 (requires bit32 installed)
 
 ## Implemented Types
 * Color3

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Lemur needs certain extra dependencies for some optional features:
 
 * dkjson (Roblox JSON API) (`luarocks install dkjson`)
 * LuaSocket (high performance timer) (`luarocks install luasocket`)
+* bit32 (Lua 5.1 bit32 implementation) (`luarocks install bit32`)
 
 Clone the Git repository wherever, then call `require` on it.
 

--- a/lib/libs/bit32.lua
+++ b/lib/libs/bit32.lua
@@ -1,0 +1,17 @@
+local exists, bit32 = pcall(require, "bit32")
+
+if exists then
+	local rbxBit32 = {}
+	for key, value in pairs(bit32) do
+		rbxBit32[key] = value
+	end
+	return rbxBit32
+else
+	return setmetatable({}, {
+		__index = function(self, index)
+			return function()
+				error("Please install `bit32` to use bit32 features.", 2)
+			end
+		end
+	})
+end

--- a/lib/libs/bit32_spec.lua
+++ b/lib/libs/bit32_spec.lua
@@ -10,7 +10,7 @@ describe("libs.bit32", function()
 		-- 010 -> 2
 		-- 101 | 010 = 111 -> 7
 		it("should bitwise OR two values", function()
-			assert.are.equals(7, bit32.bor(2, 5))
+			assert.are.equals(7, bit32.bor(5, 2))
 		end)
 	end)
 

--- a/lib/libs/bit32_spec.lua
+++ b/lib/libs/bit32_spec.lua
@@ -1,0 +1,29 @@
+local bit32 = import("./bit32")
+
+describe("libs.bit32", function()
+	describe("bor", function()
+		it("should be a function", function()
+			assert.is_function(bit32.bor)
+		end)
+
+		-- 101 -> 5
+		-- 010 -> 2
+		-- 101 | 010 = 111 -> 7
+		it("should bitwise OR two values", function()
+			assert.are.equals(7, bit32.bor(2, 5))
+		end)
+	end)
+
+	describe("band", function()
+		it("should be a function", function()
+			assert.is_function(bit32.band)
+		end)
+
+		-- 101 -> 5
+		-- 110 -> 6
+		-- 101 & 110 = 100 -> 4
+		it("should bitwise AND two values", function()
+			assert.are.equals(4, bit32.band(5, 6))
+		end)
+	end)
+end)

--- a/lib/libs/init.lua
+++ b/lib/libs/init.lua
@@ -1,4 +1,5 @@
 local names = {
+	"bit32",
 	"math",
 	"string",
 }


### PR DESCRIPTION
Added bit32 support. Requires the user to install bit32 luarock via: `sudo luarocks install bit32`

Fixes #208