### PR TITLE
instances: use fromRGB constructor for TextColor3

### DIFF
--- a/lib/instances/TextButton.lua
+++ b/lib/instances/TextButton.lua
@@ -23,7 +23,7 @@ TextButton.properties.Text = InstanceProperty.typed("string", {
 
 TextButton.properties.TextColor3 = InstanceProperty.typed("Color3", {
 	getDefault = function()
-		return Color3.new(27, 42, 53)
+		return Color3.fromRGB(27, 42, 53)
 	end,
 })
 

--- a/lib/instances/TextLabel.lua
+++ b/lib/instances/TextLabel.lua
@@ -24,7 +24,7 @@ TextLabel.properties.Text = InstanceProperty.typed("string", {
 
 TextLabel.properties.TextColor3 = InstanceProperty.typed("Color3", {
 	getDefault = function()
-		return Color3.new(27, 42, 53)
+		return Color3.fromRGB(27, 42, 53)
 	end,
 })
 


### PR DESCRIPTION
Changes the Color3 constructors from "new" to "fromRGB" for the
default value of TextColor3 in the instances "TextLabel" and
"TextButton".

Closes LPGhatguy#194

Reported-by: Kampfkarren <boynedmaster@gmail.com>